### PR TITLE
Add an additional note about using Ubuntu 19.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,17 @@ run the command `sudo modprobe r8822be`
 
 run the command `sudo nano /etc/modprobe.d/alsa-base.conf`    
 add `options snd-hda-intel model=dell-headset-multi` to the end of the file    
-reboot    
+reboot
+
+### Ubuntu 19.04 beta (stable release April 18, 2019)
+
+If none of the previous steps for fixing the Wifi issue have been met with success and you **do not wish to update the kernal**, you may have sucess using the [beta release of Ubuntu 19.04](http://rs.releases.ubuntu.com/19.04/).
+
+Ubuntu 19.04 uses Linux kernel 5.x.x which includes many of the fixes described here namely wifi, and the need to blacklist the *ideapad_laptop* kernel module.
+- [Linux kernel 5.0 overview from kernelnewbies.org](https://kernelnewbies.org/Linux_5.0)
+- [High level overview of changes by Phoronix](https://www.phoronix.com/scan.php?page=article&item=linux-2019-features&num=1)
+
+Additionally, the installation of the Nvidia drivers and Nvidia-prime packages can now be done using the builtin *Software & Updates* utility from the *Additional Drivers* tab (`nvidia-drivers-418`).
 
 # Advanced Features
 


### PR DESCRIPTION
This PR adds an additional note the **Additional Notes** section concerning using Ubuntu 19.04 rather than 18.10 in conjunction with the steps included in the guide.  

Ubuntu 19.04, currently in beta release with stable release scheduled for April 18, 2019, contains fixes for the Wifi issue and the need to blacklist the ideapad_laptop kernel module due to it being based on Linux kernel 5.

The steps added by this PR are from my experience using this guide to install Ubuntu on my Legion Y530 laptop (delivered 2 days ago).

Thanks for publishing this!


